### PR TITLE
Implement workaround for a known CJK layout bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,17 +42,25 @@ The prebuilt binaries can be found in [Releases](https://github.com/noraesae/kaw
 
 Unzip `Kawa.zip` and move `Kawa.app` to `Applications`.
 
-## Known Issues
+## For CJK input sources
 
 There is a known bug in the TIS library of macOS that switching keyboard
 layouts doesn't work well when done programmingly, especially between complex
 input sources like [CJK](https://en.wikipedia.org/wiki/CJK_characters).
-Kawa once tried to resolve this problem using hacky workaround, which caused
-more bugs, did more bad than good. The option is removed in v0.1.3, and I
-decide to wait for the fix from macOS.
 
-However, if a nice workaround is found, please upload it as an issue or PR. I
-would be happy to consider adopting it.
+Kawa workarounded this bug by programmingly doing the followings:
+
+- Select a target input source
+- If the source is CJK
+    - Switch to the first non-CJK input source
+    - Wait for `0.05`
+    - Return to the target input source by sending `Select the previous input source` shortcut
+
+Thus, to activate the workaround above, the following restrictions should meet.
+
+1. There is at least one non-CJK input source in the input source list
+2. The `Select the previous input source` shortcut should be <kbd>⌥⌘Space</kbd>
+    - It can be set in **System Preferences** > **Keyboard** > **Shortcuts** > **Input Sources**
 
 ## Preferences
 

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ Unzip `Kawa.zip` and move `Kawa.app` to `Applications`.
 ## For CJK input sources
 
 There is a known bug in the TIS library of macOS that switching keyboard
-layouts doesn't work well when done programmingly, especially between complex
+layouts doesn't work well when done programmatically, especially between complex
 input sources like [CJK](https://en.wikipedia.org/wiki/CJK_characters).
 
-Kawa workarounded this bug by programmingly doing the followings:
+Kawa workarounded this bug by programmatically doing the followings:
 
 - Select a target input source
 - If the source is CJK

--- a/README.md
+++ b/README.md
@@ -42,22 +42,22 @@ The prebuilt binaries can be found in [Releases](https://github.com/noraesae/kaw
 
 Unzip `Kawa.zip` and move `Kawa.app` to `Applications`.
 
-## For CJK input sources
+## For CJKV input sources
 
 There is a known bug in the TIS library of macOS that switching keyboard
 layouts doesn't work well when done programmatically, especially between complex
-input sources like [CJK](https://en.wikipedia.org/wiki/CJK_characters).
+input sources like [CJKV](https://en.wikipedia.org/wiki/CJK_characters).
 
 Kawa workarounded this bug by programmatically doing the followings:
 
 - Select a target input source
-- If the source is CJK
-    - Switch to the first non-CJK input source
+- If the source is CJKV
+    - Switch to the first non-CJKV input source
     - Return to the target input source by sending `Select the previous input source` shortcut
 
 Thus, to activate the workaround above, the following restrictions should meet.
 
-1. There is at least one non-CJK input source in the input source list
+1. There is at least one non-CJKV input source in the input source list
 2. The `Select the previous input source` shortcut should be enabled and set to something
     - It can be set in **System Preferences** > **Keyboard** > **Shortcuts** > **Input Sources**
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Kawa workarounded this bug by programmatically doing the followings:
 Thus, to activate the workaround above, the following restrictions should meet.
 
 1. There is at least one non-CJK input source in the input source list
-2. The `Select the previous input source` shortcut should be <kbd>⌥⌘Space</kbd>
+2. The `Select the previous input source` shortcut should be enabled and set to something
     - It can be set in **System Preferences** > **Keyboard** > **Shortcuts** > **Input Sources**
 
 ## Preferences

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ Kawa workarounded this bug by programmingly doing the followings:
 - Select a target input source
 - If the source is CJK
     - Switch to the first non-CJK input source
-    - Wait for `0.05`
     - Return to the target input source by sending `Select the previous input source` shortcut
 
 Thus, to activate the workaround above, the following restrictions should meet.

--- a/kawa.xcodeproj/project.pbxproj
+++ b/kawa.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		CC6D8EEB1B654143005682C0 /* InputSourceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6D8EEA1B654143005682C0 /* InputSourceManager.swift */; };
 		CC9AAD2B1B71AA5400626F65 /* MASShortcut.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC9AAD2A1B71AA5400626F65 /* MASShortcut.framework */; };
 		CC9AAD2C1B71AA5400626F65 /* MASShortcut.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CC9AAD2A1B71AA5400626F65 /* MASShortcut.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		EE92E8FD1F6CC98E00559B7C /* TISInputSourceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE92E8FC1F6CC98E00559B7C /* TISInputSourceExtension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -70,6 +71,7 @@
 		CC6D8EE01B654099005682C0 /* kawaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = kawaTests.swift; sourceTree = "<group>"; };
 		CC6D8EEA1B654143005682C0 /* InputSourceManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputSourceManager.swift; sourceTree = "<group>"; };
 		CC9AAD2A1B71AA5400626F65 /* MASShortcut.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MASShortcut.framework; path = Carthage/Build/Mac/MASShortcut.framework; sourceTree = "<group>"; };
+		EE92E8FC1F6CC98E00559B7C /* TISInputSourceExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TISInputSourceExtension.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -116,6 +118,7 @@
 				CC6D8ECD1B654099005682C0 /* AppDelegate.swift */,
 				CC291AD91B73635800D529B9 /* HyperlinkTextField.swift */,
 				CC6D8EEA1B654143005682C0 /* InputSourceManager.swift */,
+				EE92E8FC1F6CC98E00559B7C /* TISInputSourceExtension.swift */,
 				CC4065BF1B6DD9C3000E1E87 /* LaunchOnStartup.swift */,
 				CC69E0751B663E1E00A92F58 /* PreferenceWindowController.swift */,
 				CC4065BD1B6D334B000E1E87 /* Settings.swift */,
@@ -269,6 +272,7 @@
 				CC6D8ECE1B654099005682C0 /* AppDelegate.swift in Sources */,
 				CC4065BE1B6D334B000E1E87 /* Settings.swift in Sources */,
 				CC6D8EEB1B654143005682C0 /* InputSourceManager.swift in Sources */,
+				EE92E8FD1F6CC98E00559B7C /* TISInputSourceExtension.swift in Sources */,
 				CC69E0781B66415300A92F58 /* ShortcutViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/kawa/InputSourceManager.swift
+++ b/kawa/InputSourceManager.swift
@@ -29,7 +29,7 @@ class InputSource: Equatable {
     let tisInputSource: TISInputSource
     let id: String
     let name: String
-    let isCJK: Bool
+    let isCJKV: Bool
 
     var icon: NSImage? = nil
 
@@ -38,8 +38,11 @@ class InputSource: Equatable {
         id = InputSource.getProperty(tisInputSource, kTISPropertyInputSourceID)!
         name = InputSource.getProperty(tisInputSource, kTISPropertyLocalizedName)!
 
-        let langs: Array<String> = InputSource.getProperty(tisInputSource, kTISPropertyInputSourceLanguages)!
-        isCJK = langs.contains(where: { $0 == "ko" || $0 == "ja" || $0.hasPrefix("zh") })
+        let lang = (
+            InputSource.getProperty(tisInputSource, kTISPropertyInputSourceLanguages)!
+                as Array<String>
+        )[0]
+        isCJKV = lang == "ko" || lang == "ja" || lang == "vi" || lang.hasPrefix("zh")
 
         let imageURL: URL? = InputSource.getProperty(tisInputSource, kTISPropertyIconImageURL)
         if imageURL != nil {
@@ -61,11 +64,11 @@ class InputSource: Equatable {
     func select() {
         TISSelectInputSource(tisInputSource)
 
-        if isCJK, let selectPreviousShortcut = InputSourceManager.getSelectPreviousShortcut() {
-            // Workaround for TIS CJK layout bug:
-            // when it's CJK, select nonCJK input first and then return
-            if let nonCJK = InputSourceManager.nonCJKSource() {
-                nonCJK.select()
+        if isCJKV, let selectPreviousShortcut = InputSourceManager.getSelectPreviousShortcut() {
+            // Workaround for TIS CJKV layout bug:
+            // when it's CJKV, select nonCJKV input first and then return
+            if let nonCJKV = InputSourceManager.nonCJKVSource() {
+                nonCJKV.select()
                 InputSourceManager.selectPrevious(shortcut: selectPreviousShortcut)
             }
         }
@@ -102,8 +105,8 @@ class InputSourceManager {
             }
     }
     
-    static func nonCJKSource() -> InputSource? {
-        return inputSources.first(where: { !$0.isCJK })
+    static func nonCJKVSource() -> InputSource? {
+        return inputSources.first(where: { !$0.isCJKV })
     }
 
     static func selectPrevious(shortcut: (Int, UInt64)) {

--- a/kawa/InputSourceManager.swift
+++ b/kawa/InputSourceManager.swift
@@ -66,7 +66,6 @@ class InputSource: Equatable {
             // when it's CJK, select nonCJK input first and then return
             if let nonCJK = InputSourceManager.nonCJKSource() {
                 nonCJK.select()
-                Thread.sleep(forTimeInterval: 0.05)
                 InputSourceManager.selectPrevious()
             }
         }

--- a/kawa/InputSourceManager.swift
+++ b/kawa/InputSourceManager.swift
@@ -55,7 +55,15 @@ class InputSource: Equatable {
     }
 
     func select() {
-        TISSelectInputSource(tisInputSource)
+        let langs = InputSource.getProperty(tisInputSource, kTISPropertyInputSourceLanguages)! as Array<String>
+
+        if langs.contains(where: { $0 == "ko" || $0 == "ja" || $0.hasPrefix("zh") }) {
+            // Workaround for TIS CJK layout bug:
+            // FIXME: when it's CJK, select English first and then return
+            print("CJK")
+        } else {
+            TISSelectInputSource(tisInputSource)
+        }
     }
 
     func getRetinaImageURL(_ path: URL) -> URL {

--- a/kawa/TISInputSourceExtension.swift
+++ b/kawa/TISInputSourceExtension.swift
@@ -1,0 +1,54 @@
+//
+//  TISInputSourceExtension.swift
+//  kawa
+//
+//  Created by Yonguk Jeong on 16/09/2017.
+//  Copyright © 2017 noraesae. All rights reserved.
+//
+
+import Foundation
+
+extension TISInputSource {
+    enum Category {
+        static var keyboardInputSource: String {
+            return kTISCategoryKeyboardInputSource as String
+        }
+    }
+
+    private func getProperty(_ key: CFString) -> AnyObject? {
+        let cfType = TISGetInputSourceProperty(self, key)
+        if (cfType != nil) {
+            return Unmanaged<AnyObject>.fromOpaque(cfType!).takeUnretainedValue()
+        } else {
+            return nil
+        }
+    }
+
+    var id: String {
+        return getProperty(kTISPropertyInputSourceID) as! String
+    }
+
+    var name: String {
+        return getProperty(kTISPropertyLocalizedName) as! String
+    }
+
+    var category: String {
+        return getProperty(kTISPropertyInputSourceCategory) as! String
+    }
+
+    var isSelectable: Bool {
+        return getProperty(kTISPropertyInputSourceIsSelectCapable) as! Bool
+    }
+
+    var sourceLanguages: [String] {
+        return getProperty(kTISPropertyInputSourceLanguages) as! [String]
+    }
+
+    var iconImageURL: URL? {
+        return getProperty(kTISPropertyIconImageURL) as! URL?
+    }
+
+    var iconRef: IconRef? {
+        return OpaquePointer(TISGetInputSourceProperty(self, kTISPropertyIconRef)) as IconRef?
+    }
+}

--- a/kawa/TISInputSourceExtension.swift
+++ b/kawa/TISInputSourceExtension.swift
@@ -3,7 +3,8 @@
 //  kawa
 //
 //  Created by Yonguk Jeong on 16/09/2017.
-//  Copyright © 2017 noraesae. All rights reserved.
+//  Copyright (c) 2017 noraesae and project contributors.
+//  Licensed under the MIT License.
 //
 
 import Foundation


### PR DESCRIPTION
Fix #11 

It works like below:

- Select an input source
- If the source is CJK
    - Switch to English `com.apple.keylayout.US`
    - Wait for 0.05
    - Select previous source (in this case, the original source)