### PR TITLE
Select CJK input methods by pressing NEXT_INPUT_METHOD key

### DIFF
--- a/kawa/InputSourceManager.swift
+++ b/kawa/InputSourceManager.swift
@@ -62,8 +62,8 @@ class InputSource: Equatable {
             for _ in 0..<distance {
                 InputSourceManager.selectNext(shortcut: selectNextShortcut)
             }
-            InputSourceManager.lastSelectedInputMethod = self
         }
+        InputSourceManager.lastSelectedInputMethod = self
     }
 }
 

--- a/kawa/InputSourceManager.swift
+++ b/kawa/InputSourceManager.swift
@@ -78,7 +78,7 @@ class InputSourceManager {
 
         inputSources = inputSourceList.filter({
             $0.category == TISInputSource.Category.keyboardInputSource && $0.isSelectable
-        }).map { InputSource(tisInputSource: $0) }
+        }).map { InputSource(tisInputSource: $0) }.sorted { $0.name < $1.name }
     }
 
     static func currentSource() -> InputSource {


### PR DESCRIPTION
After upgrading to newer versions of macOS, the old workaround for CJK input methods are not working any more.

I have tried with various of switching input methods, and found that:
1. The "Select next source in input menu" shortcut works reliably.
2. The `TISCopyCurrentKeyboardInputSource` can return currently selected method reliably if there is recent key stroke or window switch.

So I have taken a policy by keep pressing "Select next source in input menu" until target input method has been switched to.

There is a bug in macOS that, if one switches to different input methods in a very short time without doing any typing, the `TISCopyCurrentKeyboardInputSource` will return wrong result. I worked around it by remembering last selected input method, and use it as current input method if user is switching input methods too fast.

Note that I don't really know much about Swift, please refactor the code if necessary.