### PR TITLE
fix kawa is not working on Catalina

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,12 @@ Kawa workarounded this bug by programmatically doing the followings:
 
 - Select a target input source
 - If the source is CJKV
-    - Switch to the first non-CJKV input source
-    - Return to the target input source by sending `Select the previous input source` shortcut
+    - Switch to the first non-CJKV input source twice with small delay
+    - Switch to the target input source
 
 Thus, to activate the workaround above, the following restrictions should meet.
 
 1. There is at least one non-CJKV input source in the input source list
-2. The `Select the previous input source` shortcut should be enabled and set to something
-    - It can be set in **System Preferences** > **Keyboard** > **Shortcuts** > **Input Sources**
 
 ## Preferences
 

--- a/kawa.xcodeproj/project.pbxproj
+++ b/kawa.xcodeproj/project.pbxproj
@@ -224,6 +224,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -404,6 +405,7 @@
 				);
 				INFOPLIST_FILE = kawa/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_BUNDLE_IDENTIFIER = "net.noraesae.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = Kawa;
 				SWIFT_OBJC_BRIDGING_HEADER = kawa/BridgingHeader.h;
@@ -423,6 +425,7 @@
 				);
 				INFOPLIST_FILE = kawa/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_BUNDLE_IDENTIFIER = "net.noraesae.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = Kawa;
 				SWIFT_OBJC_BRIDGING_HEADER = kawa/BridgingHeader.h;

--- a/kawa/InputSourceManager.swift
+++ b/kawa/InputSourceManager.swift
@@ -55,15 +55,20 @@ class InputSource: Equatable {
     }
 
     func select() {
-        TISSelectInputSource(tisInputSource)
-
-        if isCJKV, let selectPreviousShortcut = InputSourceManager.getSelectPreviousShortcut() {
+        if isCJKV {
             // Workaround for TIS CJKV layout bug:
-            // when it's CJKV, select nonCJKV input first and then return
+            // when it's CJKV, select nonCJKV input twice with delay and then select target
             if let nonCJKV = InputSourceManager.nonCJKVSource() {
                 nonCJKV.select()
-                InputSourceManager.selectPrevious(shortcut: selectPreviousShortcut)
+                Timer.scheduledTimer(withTimeInterval: 0.05, repeats: false) { _ in
+                    nonCJKV.select()
+                }
+                Timer.scheduledTimer(withTimeInterval: 0.1, repeats: false) { _ in
+                    TISSelectInputSource(self.tisInputSource)
+                }
             }
+        } else {
+            TISSelectInputSource(tisInputSource)
         }
     }
 }
@@ -82,49 +87,6 @@ class InputSourceManager {
     
     static func nonCJKVSource() -> InputSource? {
         return inputSources.first(where: { !$0.isCJKV })
-    }
-
-    static func selectPrevious(shortcut: (Int, UInt64)) {
-        let src = CGEventSource(stateID: .hidSystemState)
-
-        let key = CGKeyCode(shortcut.0)
-        let flag = CGEventFlags(rawValue: shortcut.1)
-
-        let down = CGEvent(keyboardEventSource: src, virtualKey: key, keyDown: true)!
-        let up = CGEvent(keyboardEventSource: src, virtualKey: key, keyDown: false)!
-
-        down.flags = flag;
-        up.flags = flag;
-
-        down.post(tap: .cghidEventTap)
-        up.post(tap: .cghidEventTap)
-    }
-
-    // from read-symbolichotkeys script of Karabiner
-    // github.com/tekezo/Karabiner/blob/master/src/util/read-symbolichotkeys/read-symbolichotkeys/main.m
-    static func getSelectPreviousShortcut() -> (Int, UInt64)? {
-        guard let dict = UserDefaults.standard.persistentDomain(forName: "com.apple.symbolichotkeys") else {
-            return nil
-        }
-        guard let symbolichotkeys = dict["AppleSymbolicHotKeys"] as! NSDictionary? else {
-            return nil
-        }
-        guard let symbolichotkey = symbolichotkeys["60"] as! NSDictionary? else {
-            return nil
-        }
-        if (symbolichotkey["enabled"] as! NSNumber).intValue != 1 {
-            return nil
-        }
-        guard let value = symbolichotkey["value"] as! NSDictionary? else {
-            return nil
-        }
-        guard let parameters = value["parameters"] as! NSArray? else {
-            return nil
-        }
-        return (
-            (parameters[1] as! NSNumber).intValue,
-            (parameters[2] as! NSNumber).uint64Value
-        )
     }
 }
 


### PR DESCRIPTION
Hi, I tried kawa today and found it is not working on Catalina. (10.15.4)
So I tried to find another workaround.

When changing it between **jp <-> zhTW**, this steps works
  1. switch to nonCJK and wait 0.05s
  2. switch to nonCJK and wait 0.05s again
  3. switch to zhTW

PS: I didn't test it on Korean input. Hope it works, too.