### PR TITLE
update brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A macOS input source switcher with user-defined shortcuts.
 
 ```shell
 brew update
-brew cask install kawa
+brew install --cask kawa
 ```
 
 ### Manually


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524