### PR TITLE
Fix homebrew install command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A macOS input source switcher with user-defined shortcuts.
 
 ```shell
 brew update
-brew cask install kawa
+brew install --cask kawa
 ```
 
 ### Manually


### PR DESCRIPTION
`brew cask` is now outdated and `brew install --cask` should be used instead