### PR TITLE
fix(release): Homebrew 5.0 cask + protect tap secret #00000000

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  XCODE_VERSION: "26.5"
+
+jobs:
+  build:
+    runs-on: macos-26
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Select Xcode
+        run: sudo xcode-select -s "/Applications/Xcode_${XCODE_VERSION}.app"
+
+      - name: Cache Carthage
+        uses: actions/cache@v6
+        with:
+          path: Carthage
+          key: carthage-${{ runner.os }}-xcode${{ env.XCODE_VERSION }}-${{ hashFiles('Cartfile.resolved', 'carthage.xcconfig') }}
+
+      - name: Bootstrap dependencies
+        run: make bootstrap
+
+      - name: Build (universal)
+        run: make build
+
+      - name: Dump Carthage xcodebuild log on failure
+        if: failure()
+        run: tail -n 200 "${TMPDIR}"carthage-xcodebuild.*.log || true
+
+  swiftlint:
+    runs-on: ubuntu-latest
+    container: ghcr.io/realm/swiftlint:0.57.0
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: SwiftLint
+        run: swiftlint lint
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: ShellCheck
+        run: shellcheck scripts/*.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ env:
 jobs:
   release:
     runs-on: macos-26
+    # TAP_GITHUB_TOKEN lives in this environment (protected branches only),
+    # not in repo secrets - a workflow pushed to a side branch cannot read it.
+    environment: release
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,105 @@
+name: Release
+
+# Version source of truth is kawa/Info.plist (CFBundleShortVersionString).
+# The tag v<version> is created by this workflow only - never locally.
+# Order: build first, tag and publish only after a successful build, so a
+# build failure needs no rollback; rollback covers only the narrow window
+# between tag creation and a failed publish. A published release is never
+# rolled back - a failed cask bump leaves the release in place and the lag
+# is visible in `make status`.
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+env:
+  XCODE_VERSION: "26.5"
+
+jobs:
+  release:
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Select Xcode
+        run: sudo xcode-select -s "/Applications/Xcode_${XCODE_VERSION}.app"
+
+      - name: Read version from Info.plist
+        id: version
+        run: |
+          version="$(make print-version)"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          if git ls-remote --exit-code origin "refs/tags/v${version}" >/dev/null 2>&1; then
+            echo "FAIL: tag v${version} already exists - bump kawa/Info.plist first" >&2
+            exit 1
+          fi
+
+      - name: Extract release notes from CHANGELOG
+        run: |
+          mkdir -p build
+          scripts/changelog-extract.sh "${{ steps.version.outputs.version }}" > build/notes.md
+
+      - name: Cache Carthage
+        uses: actions/cache@v6
+        with:
+          path: Carthage
+          key: carthage-${{ runner.os }}-xcode${{ env.XCODE_VERSION }}-${{ hashFiles('Cartfile.resolved', 'carthage.xcconfig') }}
+
+      - name: Build distribution
+        run: make dist
+
+      - name: Create tag
+        id: tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${{ steps.version.outputs.version }}" -m "kawa v${{ steps.version.outputs.version }}"
+          git push origin "v${{ steps.version.outputs.version }}"
+
+      - name: Publish GitHub release
+        id: publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ steps.version.outputs.version }}" \
+            build/Kawa.zip build/Kawa.zip.sha256 \
+            --title "v${{ steps.version.outputs.version }}" \
+            --notes-file build/notes.md
+
+      - name: Checkout Homebrew tap
+        uses: actions/checkout@v7
+        with:
+          repository: Windemiatrix/homebrew-tap
+          token: ${{ secrets.TAP_GITHUB_TOKEN }}
+          path: tap
+
+      - name: Update Homebrew cask
+        run: |
+          sha256="$(cat build/Kawa.zip.sha256)"
+          scripts/update-cask.sh "${{ steps.version.outputs.version }}" "${sha256}" tap
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Casks/kawa.rb
+          if git diff --cached --quiet; then
+            echo "Cask already up to date - nothing to commit"
+          else
+            git commit -m "Cask update for kawa v${{ steps.version.outputs.version }}"
+            git push
+          fi
+
+      - name: Rollback tag on failed publish
+        if: failure() && steps.tag.outcome == 'success' && steps.publish.outcome != 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release delete "v${{ steps.version.outputs.version }}" -y || true
+          git push origin ":refs/tags/v${{ steps.version.outputs.version }}" || true

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,10 @@
+included:
+  - kawa
+excluded:
+  - Carthage
+  - build
+disabled_rules:
+  - todo
+  - identifier_name
+  - line_length
+  - force_cast

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.2.0 (25 Jul 2026)
+
+* First release of the Windemiatrix/kawa fork.
+* Fork: universal binary (arm64 + x86_64), built and released via GitHub Actions.
+* Fork: distribution through the windemiatrix/tap Homebrew tap (cask, ad-hoc signed).
+* Inherited from upstream master (unreleased since 1.1.0): always show the
+  status bar icon; remove CJK-specific input source logic; remove the
+  'Launch at startup' option; Swift 5, macOS deployment target 10.15;
+  internal refactorings and file reorganization.
+
 ## 1.1.0 (10 Nov 2017)
 
 * Remove previous notifications on new one (#17)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,91 @@
+# Makefile - build and release tooling for the kawa fork.
+SHELL := /bin/bash
+
+SCHEME := kawa
+PROJECT := kawa.xcodeproj
+BUILD_DIR := build
+ARCHIVE := $(BUILD_DIR)/kawa.xcarchive
+APP := $(BUILD_DIR)/Kawa.app
+ZIP := $(BUILD_DIR)/Kawa.zip
+
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ Build
+
+.PHONY: bootstrap
+bootstrap: ## fetch and build Carthage deps (universal: --no-use-binaries)
+	XCODE_XCCONFIG_FILE="$(CURDIR)/carthage.xcconfig" carthage bootstrap --platform macOS --no-use-binaries --cache-builds
+
+.PHONY: build
+build: ## build the app (Release, universal arm64+x86_64)
+	xcodebuild -project $(PROJECT) -scheme $(SCHEME) -configuration Release build ONLY_ACTIVE_ARCH=NO ARCHS="arm64 x86_64" -derivedDataPath $(BUILD_DIR)/DerivedData CODE_SIGN_IDENTITY=-
+
+##@ Distribution
+
+.PHONY: archive
+archive: ## xcodebuild archive (universal arm64+x86_64)
+	xcodebuild -project $(PROJECT) -scheme $(SCHEME) archive -archivePath $(ARCHIVE) ONLY_ACTIVE_ARCH=NO ARCHS="arm64 x86_64"
+
+.PHONY: export
+export: archive ## extract Kawa.app from the archive
+	rm -rf "$(APP)"
+	ditto "$(ARCHIVE)/Products/Applications/Kawa.app" "$(APP)"
+
+.PHONY: zip
+zip: export ## zip Kawa.app with ditto
+	ditto -c -k --sequesterRsrc --keepParent "$(APP)" "$(ZIP)"
+
+.PHONY: sha256
+sha256: zip ## write and print the zip's sha256 checksum
+	shasum -a 256 "$(ZIP)" | awk '{ print $$1 }' > "$(ZIP).sha256"
+	cat "$(ZIP).sha256"
+
+.PHONY: verify-dist
+verify-dist: ## check universal arch (arm64+x86_64) and codesign of the built app
+	@arch_bin="$$(lipo -archs "$(APP)/Contents/MacOS/Kawa")"; \
+	echo "$$arch_bin" | grep -q arm64 || { echo "FAIL: $(APP)/Contents/MacOS/Kawa missing arm64" >&2; exit 1; }; \
+	echo "$$arch_bin" | grep -q x86_64 || { echo "FAIL: $(APP)/Contents/MacOS/Kawa missing x86_64" >&2; exit 1; }
+	@arch_fw="$$(lipo -archs "$(APP)/Contents/Frameworks/MASShortcut.framework/MASShortcut")"; \
+	echo "$$arch_fw" | grep -q arm64 || { echo "FAIL: MASShortcut.framework missing arm64" >&2; exit 1; }; \
+	echo "$$arch_fw" | grep -q x86_64 || { echo "FAIL: MASShortcut.framework missing x86_64" >&2; exit 1; }
+	codesign --verify --deep --strict "$(APP)"
+	@echo "OK: verify-dist passed"
+
+.PHONY: dist
+dist: ## full release artifact chain: bootstrap+archive+export+zip+sha256+verify-dist
+	$(MAKE) bootstrap
+	$(MAKE) sha256
+	$(MAKE) verify-dist
+
+##@ Version
+
+.PHONY: print-version
+print-version: ## print current CFBundleShortVersionString
+	@scripts/version.sh
+
+.PHONY: bump-version
+bump-version: ## set CFBundleShortVersionString (make bump-version VERSION=X.Y.Z)
+	@if [ -z "$(VERSION)" ]; then \
+		echo "Usage: make bump-version VERSION=X.Y.Z" >&2; \
+		exit 1; \
+	fi
+	scripts/bump-version.sh "$(VERSION)"
+
+.PHONY: status
+status: ## compare info.plist, latest GitHub release and Homebrew cask versions
+	@scripts/status.sh
+
+##@ Quality
+
+.PHONY: lint
+lint: ## swiftlint + shellcheck
+	swiftlint lint
+	shellcheck scripts/*.sh
+
+##@ Cleanup
+
+.PHONY: clean
+clean: ## remove build/
+	rm -rf $(BUILD_DIR)

--- a/README.md
+++ b/README.md
@@ -20,12 +20,13 @@ released and adds its own release pipeline:
 
 ### Using [Homebrew](https://brew.sh/)
 
-`Kawa.app` is ad-hoc signed and not notarized, so Gatekeeper blocks a
-quarantined copy. Install without quarantine:
-
 ```shell
-brew install --cask --no-quarantine windemiatrix/tap/kawa
+brew install --cask windemiatrix/tap/kawa
 ```
+
+`Kawa.app` is ad-hoc signed and not notarized. The cask clears the Gatekeeper
+quarantine attribute on install, so the app launches normally. (Homebrew 5.0
+removed the `--no-quarantine` flag; the cask does this itself.)
 
 ### Manually
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 ![logo](resource/png/logo.png)
 
-# Kawa [![GitHub license](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://raw.githubusercontent.com/utatti/kawa/master/LICENSE) [![GitHub release](https://img.shields.io/github/release/utatti/kawa.svg)](https://github.com/utatti/kawa/releases)
+# Kawa [![GitHub license](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://raw.githubusercontent.com/Windemiatrix/kawa/master/LICENSE) [![GitHub release](https://img.shields.io/github/release/Windemiatrix/kawa.svg)](https://github.com/Windemiatrix/kawa/releases)
 
 A macOS input source switcher with user-defined shortcuts.
+
+This is a personal fork of [hatashiro/kawa](https://github.com/hatashiro/kawa).
+Upstream is unmaintained; the fork ships the upstream changes that never got
+released and adds its own release pipeline:
+
+- Universal binary (arm64 + x86_64), built and released via GitHub Actions.
+- Distribution through the `windemiatrix/tap` Homebrew tap (cask, ad-hoc signed).
+- Requires macOS 10.15 (Catalina) or later.
 
 ## Demo
 
@@ -12,44 +20,69 @@ A macOS input source switcher with user-defined shortcuts.
 
 ### Using [Homebrew](https://brew.sh/)
 
+`Kawa.app` is ad-hoc signed and not notarized, so Gatekeeper blocks a
+quarantined copy. Install without quarantine:
+
 ```shell
-brew update
-brew install --cask kawa
+brew install --cask --no-quarantine windemiatrix/tap/kawa
 ```
 
 ### Manually
 
-The prebuilt binaries can be found in [Releases](https://github.com/utatti/kawa/releases).
+The prebuilt binaries can be found in
+[Releases](https://github.com/Windemiatrix/kawa/releases).
 
-Unzip `Kawa.zip` and move `Kawa.app` to `Applications`.
+Unzip `Kawa.zip`, move `Kawa.app` to `Applications`, and clear the quarantine
+attribute:
 
-## Caveats
-
-### CJKV input sources
-
-There is a known bug in the macOS's Carbon library that switching keyboard
-layouts using `TISSelectInputSource` doesn't work well with complex input
-sources like [CJKV](https://en.wikipedia.org/wiki/CJK_characters).
+```shell
+xattr -cr /Applications/Kawa.app
+```
 
 ## Development
 
-We use [Carthage](https://github.com/Carthage/Carthage) as a dependency manager.
-You can find the latest releases of Carthage [here](https://github.com/Carthage/Carthage/releases),
-or just install it with [Homebrew](http://brew.sh).
+We use [Carthage](https://github.com/Carthage/Carthage) as a dependency
+manager; install it with `brew install carthage`.
 
-```bash
-$ brew update
-$ brew install carthage
+```shell
+git clone git@github.com:Windemiatrix/kawa.git
+cd kawa
+make bootstrap
 ```
 
-To clone the Git repository of Kawa and install dependencies:
+`make bootstrap` builds the dependencies from source (`--no-use-binaries`) so
+the frameworks come out universal. After that, open the project with Xcode or
+build from the command line:
 
-```bash
-$ git clone git@github.com:utatti/kawa.git
-$ carthage bootstrap
+```shell
+make help    # list all targets
+make build   # Release build, universal arm64 + x86_64
+make lint    # swiftlint + shellcheck
 ```
 
-After dependency installation, open the project with Xcode.
+## Release
+
+The version source of truth is `kawa/Info.plist`:
+
+```shell
+make bump-version VERSION=X.Y.Z
+```
+
+Commit the bump together with a `## X.Y.Z (date)` section in `CHANGELOG.md`,
+then run the manual `Release` workflow on GitHub Actions. It builds the
+universal binary, creates the `vX.Y.Z` tag and the GitHub release, and updates
+the Homebrew cask in `Windemiatrix/homebrew-tap`. `make status` shows whether
+`Info.plist`, the latest GitHub release, and the cask are in sync.
+
+First-release prerequisites: the `Windemiatrix/homebrew-tap` repository must
+exist, and the `TAP_GITHUB_TOKEN` repository secret must hold a token with
+write access to it.
+
+A published release is never rolled back on a failed cask bump; `make status`
+shows the lag. To recover without cutting a new version, update the cask in a
+tap clone manually: `scripts/update-cask.sh <version> <sha256> <tap-clone>`
+(the sha256 is in the release's `Kawa.zip.sha256` asset), then commit and
+push the tap.
 
 ## License
 

--- a/carthage.xcconfig
+++ b/carthage.xcconfig
@@ -1,0 +1,8 @@
+// MASShortcut 2.4.0 targets macOS 10.10/10.11; Xcode 26 rejects deployment
+// targets below its supported floor. Carthage forwards this file to every
+// dependency build (XCODE_XCCONFIG_FILE) - pin deps to the app's own target.
+MACOSX_DEPLOYMENT_TARGET = 10.15
+
+// MASShortcut (ObjC) sets GCC_TREAT_WARNINGS_AS_ERRORS=YES; SDK 26 deprecation
+// warnings (Carbon-era APIs) would fail the build of an upstream we do not patch.
+GCC_TREAT_WARNINGS_AS_ERRORS = NO

--- a/kawa.xcodeproj/xcshareddata/xcschemes/kawa.xcscheme
+++ b/kawa.xcodeproj/xcshareddata/xcschemes/kawa.xcscheme
@@ -20,20 +20,6 @@
                ReferencedContainer = "container:kawa.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CC6D8ED91B654099005682C0"
-               BuildableName = "kawaTests.xctest"
-               BlueprintName = "kawaTests"
-               ReferencedContainer = "container:kawa.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -51,16 +37,6 @@
          </BuildableReference>
       </MacroExpansion>
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CC6D8ED91B654099005682C0"
-               BuildableName = "kawaTests.xctest"
-               BlueprintName = "kawaTests"
-               ReferencedContainer = "container:kawa.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/kawa/Info.plist
+++ b/kawa/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
+	<string>1.2.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>
@@ -29,7 +29,7 @@
 	<key>LSUIElement</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2015-2017 utatti. All rights reserved.</string>
+	<string>Copyright © 2015-2021 utatti. Copyright © 2026 Roman Martsev. All rights reserved.</string>
 	<key>NSMainStoryboardFile</key>
 	<string>Main</string>
 	<key>NSPrincipalClass</key>

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# bump-version.sh - set CFBundleShortVersionString to a new version and
+# increment CFBundleVersion (build number) by 1.
+#
+# macOS-only: requires /usr/libexec/PlistBuddy. Does not touch git.
+#
+# Usage: bump-version.sh X.Y.Z
+set -euo pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") X.Y.Z" >&2
+  exit 1
+}
+
+[[ $# -eq 1 ]] || usage
+
+new_version="$1"
+[[ "${new_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || usage
+
+PLISTBUDDY=/usr/libexec/PlistBuddy
+if [[ ! -x "${PLISTBUDDY}" ]]; then
+  echo "FAIL: requires a macOS host (PlistBuddy)" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${SCRIPT_DIR}/.."
+PLIST="${REPO_ROOT}/kawa/Info.plist"
+
+if [[ ! -f "${PLIST}" ]]; then
+  echo "FAIL: ${PLIST} not found" >&2
+  exit 1
+fi
+
+old_version="$("${PLISTBUDDY}" -c "Print :CFBundleShortVersionString" "${PLIST}")"
+old_build="$("${PLISTBUDDY}" -c "Print :CFBundleVersion" "${PLIST}")"
+new_build=$((old_build + 1))
+
+"${PLISTBUDDY}" -c "Set :CFBundleShortVersionString ${new_version}" "${PLIST}"
+"${PLISTBUDDY}" -c "Set :CFBundleVersion ${new_build}" "${PLIST}"
+
+echo "${old_version} -> ${new_version}"

--- a/scripts/cask-template.rb
+++ b/scripts/cask-template.rb
@@ -17,6 +17,13 @@ cask "kawa" do
 
   app "Kawa.app"
 
+  # Kawa.app is ad-hoc signed, not notarized; Homebrew 5.0 removed the
+  # --no-quarantine flag, so strip the quarantine attribute here instead.
+  postflight do
+    system_command "/usr/bin/xattr",
+                   args: ["-dr", "com.apple.quarantine", "#{appdir}/Kawa.app"]
+  end
+
   uninstall quit: "net.noraesae.Kawa"
 
   zap trash: [
@@ -26,14 +33,12 @@ cask "kawa" do
 
   caveats do
     <<~EOS
-      Kawa.app is ad-hoc signed and NOT notarized. Gatekeeper will block the
-      first launch of a quarantined copy. Install without quarantine:
+      Kawa.app is ad-hoc signed and NOT notarized. The cask clears the
+      Gatekeeper quarantine attribute on install, so the app launches normally.
+      If macOS still blocks it (for example after a manual move), clear the
+      attribute yourself:
 
-        brew install --cask --no-quarantine windemiatrix/tap/kawa
-
-      Or clear the attribute after install:
-
-        xattr -cr /Applications/Kawa.app
+        xattr -dr com.apple.quarantine /Applications/Kawa.app
     EOS
   end
 end

--- a/scripts/cask-template.rb
+++ b/scripts/cask-template.rb
@@ -1,0 +1,39 @@
+cask "kawa" do
+  version "0.0.0"
+  # version and sha256 are machine-managed by release.yml in Windemiatrix/kawa.
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+
+  url "https://github.com/Windemiatrix/kawa/releases/download/v#{version}/Kawa.zip"
+  name "Kawa"
+  desc "Menu-bar input source switcher with per-source shortcuts (personal fork)"
+  homepage "https://github.com/Windemiatrix/kawa"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :catalina"
+
+  app "Kawa.app"
+
+  uninstall quit: "net.noraesae.Kawa"
+
+  zap trash: [
+    "~/Library/Application Support/Kawa",
+    "~/Library/Preferences/net.noraesae.Kawa.plist",
+  ]
+
+  caveats do
+    <<~EOS
+      Kawa.app is ad-hoc signed and NOT notarized. Gatekeeper will block the
+      first launch of a quarantined copy. Install without quarantine:
+
+        brew install --cask --no-quarantine windemiatrix/tap/kawa
+
+      Or clear the attribute after install:
+
+        xattr -cr /Applications/Kawa.app
+    EOS
+  end
+end

--- a/scripts/changelog-extract.sh
+++ b/scripts/changelog-extract.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# changelog-extract.sh - print the CHANGELOG.md section body for a version.
+#
+# Section body is everything after the heading '## X.Y.Z (date)' up to
+# (but not including) the next '## ' heading, with surrounding blank lines
+# trimmed. Fails fast (before tagging) if the section is missing or empty.
+#
+# Usage: changelog-extract.sh X.Y.Z
+set -euo pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") X.Y.Z" >&2
+  exit 1
+}
+
+[[ $# -eq 1 ]] || usage
+
+version="$1"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${SCRIPT_DIR}/.."
+CHANGELOG="${REPO_ROOT}/CHANGELOG.md"
+
+if [[ ! -f "${CHANGELOG}" ]]; then
+  echo "FAIL: ${CHANGELOG} not found" >&2
+  exit 1
+fi
+
+found=0
+lines=()
+
+while IFS= read -r line || [[ -n "${line}" ]]; do
+  if [[ "${found}" -eq 1 ]]; then
+    case "${line}" in
+      "## "*) break ;;
+    esac
+    lines+=("${line}")
+  else
+    case "${line}" in
+      "## ${version}" | "## ${version} "*) found=1 ;;
+    esac
+  fi
+done < "${CHANGELOG}"
+
+if [[ "${found}" -eq 0 ]]; then
+  echo "FAIL: no changelog section found for version ${version}" >&2
+  exit 1
+fi
+
+# Trim leading blank lines.
+start=0
+while [[ "${start}" -lt "${#lines[@]}" && -z "${lines[${start}]}" ]]; do
+  start=$((start + 1))
+done
+
+# Trim trailing blank lines.
+end=$((${#lines[@]} - 1))
+while [[ "${end}" -ge "${start}" && -z "${lines[${end}]}" ]]; do
+  end=$((end - 1))
+done
+
+if [[ "${end}" -lt "${start}" ]]; then
+  echo "FAIL: changelog section for version ${version} is empty" >&2
+  exit 1
+fi
+
+for ((i = start; i <= end; i++)); do
+  printf '%s\n' "${lines[${i}]}"
+done

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# status.sh - compare kawa versions across info.plist, the latest GitHub
+# release, and the Homebrew cask.
+#
+# Reads the pipeline in order: kawa/Info.plist (source of truth, via
+# scripts/version.sh), the latest GitHub release tag, and the version
+# pinned in Windemiatrix/homebrew-tap's Casks/kawa.rb. A published release
+# is never rolled back on a failed cask bump, so any lag must show up here.
+#
+# A network failure or a repo with no releases yet degrades the affected
+# value to "unavailable", reported as such rather than as a version lag.
+#
+# Usage: status.sh
+set -euo pipefail
+
+usage() {
+  echo "Usage: $(basename "$0")" >&2
+  exit 1
+}
+
+[[ $# -eq 0 ]] || usage
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+GITHUB_RELEASE_URL="https://api.github.com/repos/Windemiatrix/kawa/releases/latest"
+# HEAD resolves to the tap's default branch, whatever it is named.
+CASK_RAW_URL="https://raw.githubusercontent.com/Windemiatrix/homebrew-tap/HEAD/Casks/kawa.rb"
+
+# version_lt A B - true (exit 0) if semver A is numerically less than B.
+# A missing component compares as 0 (e.g. "1.2" vs "1.2.0").
+version_lt() {
+  local a="$1" b="$2"
+  local a_parts=() b_parts=()
+  IFS='.' read -ra a_parts <<< "${a}"
+  IFS='.' read -ra b_parts <<< "${b}"
+  local i an bn
+  for i in 0 1 2; do
+    an="${a_parts[i]:-0}"
+    bn="${b_parts[i]:-0}"
+    if [[ "${an}" -lt "${bn}" ]]; then
+      return 0
+    elif [[ "${an}" -gt "${bn}" ]]; then
+      return 1
+    fi
+  done
+  return 1
+}
+
+local_version="$("${SCRIPT_DIR}/version.sh")"
+
+github_json="$(curl -fsS "${GITHUB_RELEASE_URL}" 2>/dev/null)" || github_json=""
+github_tag="unavailable"
+if [[ -n "${github_json}" ]]; then
+  github_tag="$(printf '%s\n' "${github_json}" |
+    sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+  github_tag="${github_tag%%$'\n'*}"
+  github_tag="${github_tag#v}"
+  [[ -n "${github_tag}" ]] || github_tag="unavailable"
+fi
+
+cask_content="$(curl -fsS "${CASK_RAW_URL}" 2>/dev/null)" || cask_content=""
+cask_version="unavailable"
+if [[ -n "${cask_content}" ]]; then
+  cask_version="$(printf '%s\n' "${cask_content}" |
+    sed -n 's/^[[:space:]]*version "\([^"]*\)".*/\1/p')"
+  cask_version="${cask_version%%$'\n'*}"
+  [[ -n "${cask_version}" ]] || cask_version="unavailable"
+fi
+
+printf '%-17s%s\n' "info.plist:" "${local_version}"
+printf '%-17s%s\n' "github release:" "${github_tag}"
+printf '%-17s%s\n' "cask:" "${cask_version}"
+
+warnings=()
+
+if [[ "${github_tag}" == "unavailable" ]]; then
+  warnings+=("github release unavailable")
+elif [[ "${local_version}" != "${github_tag}" ]]; then
+  if version_lt "${github_tag}" "${local_version}"; then
+    warnings+=("github release (${github_tag}) lags behind info.plist (${local_version})")
+  else
+    warnings+=("info.plist (${local_version}) lags behind github release (${github_tag})")
+  fi
+fi
+
+if [[ "${cask_version}" == "unavailable" ]]; then
+  warnings+=("cask unavailable")
+elif [[ "${github_tag}" != "unavailable" && "${github_tag}" != "${cask_version}" ]]; then
+  if version_lt "${cask_version}" "${github_tag}"; then
+    warnings+=("cask (${cask_version}) lags behind github release (${github_tag})")
+  else
+    warnings+=("github release (${github_tag}) lags behind cask (${cask_version})")
+  fi
+fi
+
+if [[ "${#warnings[@]}" -eq 0 ]]; then
+  echo "OK: versions in sync"
+  exit 0
+fi
+
+joined="${warnings[0]}"
+for ((i = 1; i < ${#warnings[@]}; i++)); do
+  joined="${joined}; ${warnings[i]}"
+done
+echo "Warning: ${joined}"
+exit 1

--- a/scripts/update-cask.sh
+++ b/scripts/update-cask.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# update-cask.sh - update version and sha256 in a Homebrew cask file.
+#
+# Edits <tap-dir>/Casks/kawa.rb in place, portably (sed to a temp file + mv,
+# no 'sed -i'): the line matching leading whitespace + 'version "..."' gets
+# the new version, and the 'sha256 "..."' line gets the new digest.
+#
+# No git operations here - commit/push of the tap repo live in the GitHub
+# workflow, not in this script.
+#
+# Usage: update-cask.sh <version> <sha256> <tap-checkout-dir>
+set -euo pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") <version> <sha256> <tap-checkout-dir>" >&2
+  exit 1
+}
+
+[[ $# -eq 3 ]] || usage
+
+version="$1"
+sha256="$2"
+tap_dir="$3"
+
+# Keep the ERE pattern in a variable (bash 3.2 quirk: an inline literal
+# passed to [[ =~ ]] can be parsed differently depending on quoting).
+version_re='^[0-9]+\.[0-9]+\.[0-9]+$'
+sha256_re='^[0-9a-f]{64}$'
+
+if [[ ! "${version}" =~ ${version_re} ]]; then
+  echo "FAIL: version '${version}' is not in X.Y.Z format" >&2
+  exit 1
+fi
+
+if [[ ! "${sha256}" =~ ${sha256_re} ]]; then
+  echo "FAIL: sha256 '${sha256}' is not a 64-character lowercase hex digest" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+template_file="${SCRIPT_DIR}/cask-template.rb"
+
+cask_file="${tap_dir}/Casks/kawa.rb"
+
+if [[ ! -f "${cask_file}" ]]; then
+  echo "Info: bootstrapping Casks/kawa.rb from template"
+  mkdir -p "${tap_dir}/Casks"
+  cp "${template_file}" "${cask_file}"
+fi
+
+tmp_file="$(mktemp "${cask_file}.XXXXXX")"
+cleanup() { rm -f "${tmp_file}"; }
+trap cleanup EXIT INT TERM
+
+sed -e "s/^\([[:space:]]*\)version \"[^\"]*\"/\1version \"${version}\"/" \
+    -e "s/^\([[:space:]]*\)sha256 \"[^\"]*\"/\1sha256 \"${sha256}\"/" \
+    "${cask_file}" > "${tmp_file}"
+
+mv "${tmp_file}" "${cask_file}"
+
+if ! grep -qF "version \"${version}\"" "${cask_file}"; then
+  echo "FAIL: version was not updated in ${cask_file}" >&2
+  exit 1
+fi
+
+if ! grep -qF "sha256 \"${sha256}\"" "${cask_file}"; then
+  echo "FAIL: sha256 was not updated in ${cask_file}" >&2
+  exit 1
+fi
+
+echo "OK: ${cask_file} updated to version ${version}"

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# version.sh - print CFBundleShortVersionString from kawa/Info.plist.
+#
+# Works on macOS (via /usr/libexec/PlistBuddy when executable) and on Linux
+# (fallback: awk over the raw XML - the value is on the line after the key).
+# Prints the bare version (e.g. "1.2.0") to stdout, nothing else.
+set -euo pipefail
+
+usage() {
+  echo "Usage: $(basename "$0")" >&2
+  exit 1
+}
+
+[[ $# -eq 0 ]] || usage
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${SCRIPT_DIR}/.."
+PLIST="${REPO_ROOT}/kawa/Info.plist"
+
+if [[ ! -f "${PLIST}" ]]; then
+  echo "FAIL: ${PLIST} not found" >&2
+  exit 1
+fi
+
+if [[ -x /usr/libexec/PlistBuddy ]]; then
+  /usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "${PLIST}"
+else
+  awk '
+    /<key>CFBundleShortVersionString<\/key>/ {
+      getline
+      line = $0
+      sub(/^[^<]*<string>/, "", line)
+      sub(/<\/string>.*$/, "", line)
+      print line
+      exit
+    }
+  ' "${PLIST}"
+fi


### PR DESCRIPTION
## Какую проблему решает

Homebrew 5.0 удалил флаг `--no-quarantine` — команда установки из README и
caveats cask перестала работать, а ad-hoc подписанное приложение блокируется
Gatekeeper. Отдельно: `TAP_GITHUB_TOKEN` лежал на repo-уровне и был бы доступен
любому workflow с любой ветки.

## Как решает

Cask снимает атрибут карантина в `postflight` (`xattr -dr com.apple.quarantine`),
README и caveats — без удалённого флага. Секрет перенесён в GitHub Environment
`release` с политикой protected-branches-only: workflow вне `master` его не прочитает.